### PR TITLE
Fix typo in dune build file

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@
   (modules_without_implementation desugared sugared)
   (preprocess (pps sedlex.ppx))
   (flags -w +a-4-27-29-50 -warn-error +a)
-  (libraries unix sedlex menhirlib))
+  (libraries unix sedlex menhirLib))
 
 (menhir
   (flags "--explain")


### PR DESCRIPTION
This pull request resolves issue #3 with the dune build file on Linux. The expected library name for menhir is `menhirLib`.